### PR TITLE
Library shouldn't use 3rd party types in the public API

### DIFF
--- a/invoices.go
+++ b/invoices.go
@@ -2,19 +2,17 @@ package scoro
 
 import (
 	"errors"
-
-	"github.com/shopspring/decimal"
 )
 
 // InvoiceLine struct represents invoice lines data type of Scoro API.
 // https://api.scoro.com/api/#invoiceLinesApiDocs
 type InvoiceLine struct {
-	ProductID int             `json:"product_id"`
-	UnitPrice decimal.Decimal `json:"price"`
-	Amount    decimal.Decimal `json:"amount"`
-	Sum       decimal.Decimal `json:"sum"`
-	Vat       decimal.Decimal `json:"vat"`
-	Comment   Strings         `json:"comment"`
+	ProductID int     `json:"product_id"`
+	UnitPrice Decimal `json:"price"`
+	Amount    Decimal `json:"amount"`
+	Sum       Decimal `json:"sum"`
+	Vat       Decimal `json:"vat"`
+	Comment   Strings `json:"comment"`
 }
 
 // Invoice struct represents invoices data type of Scoro API.
@@ -31,9 +29,9 @@ type Invoice struct {
 	Discount                 float32           `json:"discount,omitempty"`
 	Discount2                float32           `json:"discount2,omitempty"`
 	Discount3                float32           `json:"discount3,omitempty"`
-	Sum                      decimal.Decimal   `json:"sum,omitempty"`
-	VatSum                   decimal.Decimal   `json:"vat_sum,omitempty"`
-	Vat                      decimal.Decimal   `json:"vat,omitempty"`
+	Sum                      Decimal           `json:"sum,omitempty"`
+	VatSum                   Decimal           `json:"vat_sum,omitempty"`
+	Vat                      Decimal           `json:"vat,omitempty"`
 	CompanyID                int               `json:"company_id,omitempty"`
 	PersonID                 int               `json:"person_id,omitempty"`
 	CompanyAddressID         int               `json:"company_address_id,omitempty"`

--- a/orders.go
+++ b/orders.go
@@ -2,19 +2,17 @@ package scoro
 
 import (
 	"errors"
-
-	"github.com/shopspring/decimal"
 )
 
 // OrderLine struct represents order lines data type of Scoro API.
 // https://api.scoro.com/api/#orderLinesApiDocs
 type OrderLine struct {
-	ProductID int             `json:"product_id"`
-	UnitPrice decimal.Decimal `json:"price"`
-	Amount    decimal.Decimal `json:"amount"`
-	Sum       decimal.Decimal `json:"sum"`
-	Vat       decimal.Decimal `json:"vat"`
-	Comment   Strings         `json:"comment"`
+	ProductID int     `json:"product_id"`
+	UnitPrice Decimal `json:"price"`
+	Amount    Decimal `json:"amount"`
+	Sum       Decimal `json:"sum"`
+	Vat       Decimal `json:"vat"`
+	Comment   Strings `json:"comment"`
 }
 
 // Order struct represents orders data type of Scoro API.
@@ -26,9 +24,9 @@ type Order struct {
 	Discount                 float32           `json:"discount,omitempty"`
 	Discount2                float32           `json:"discount2,omitempty"`
 	Discount3                float32           `json:"discount3,omitempty"`
-	Sum                      decimal.Decimal   `json:"sum,omitempty"`
-	VatSum                   decimal.Decimal   `json:"vat_sum,omitempty"`
-	Vat                      decimal.Decimal   `json:"vat,omitempty"`
+	Sum                      Decimal           `json:"sum,omitempty"`
+	VatSum                   Decimal           `json:"vat_sum,omitempty"`
+	Vat                      Decimal           `json:"vat,omitempty"`
 	CompanyID                int               `json:"company_id,omitempty"`
 	PersonID                 int               `json:"person_id,omitempty"`
 	CompanyAddressID         int               `json:"company_address_id,omitempty"`

--- a/prepayments.go
+++ b/prepayments.go
@@ -2,19 +2,17 @@ package scoro
 
 import (
 	"errors"
-
-	"github.com/shopspring/decimal"
 )
 
 // PrepaymentLine struct represents prepayment lines data type of Scoro API.
 // https://api.scoro.com/api/#prepaymentLinesApiDocs
 type PrepaymentLine struct {
-	ProductID int             `json:"product_id"`
-	UnitPrice decimal.Decimal `json:"price"`
-	Amount    decimal.Decimal `json:"amount"`
-	Sum       decimal.Decimal `json:"sum"`
-	Vat       decimal.Decimal `json:"vat"`
-	Comment   Strings         `json:"comment"`
+	ProductID int     `json:"product_id"`
+	UnitPrice Decimal `json:"price"`
+	Amount    Decimal `json:"amount"`
+	Sum       Decimal `json:"sum"`
+	Vat       Decimal `json:"vat"`
+	Comment   Strings `json:"comment"`
 }
 
 // Prepayment struct represents prepayments data type of Scoro API.
@@ -31,9 +29,9 @@ type Prepayment struct {
 	Discount                 float32           `json:"discount,omitempty"`
 	Discount2                float32           `json:"discount2,omitempty"`
 	Discount3                float32           `json:"discount3,omitempty"`
-	Sum                      decimal.Decimal   `json:"sum,omitempty"`
-	VatSum                   decimal.Decimal   `json:"vat_sum,omitempty"`
-	Vat                      decimal.Decimal   `json:"vat,omitempty"`
+	Sum                      Decimal           `json:"sum,omitempty"`
+	VatSum                   Decimal           `json:"vat_sum,omitempty"`
+	Vat                      Decimal           `json:"vat,omitempty"`
 	CompanyID                int               `json:"company_id,omitempty"`
 	PersonID                 int               `json:"person_id,omitempty"`
 	CompanyAddressID         int               `json:"company_address_id,omitempty"`

--- a/products.go
+++ b/products.go
@@ -2,8 +2,6 @@ package scoro
 
 import (
 	"errors"
-
-	"github.com/shopspring/decimal"
 )
 
 // Product struct represents products data type of Scoro API.
@@ -13,8 +11,8 @@ type Product struct {
 	Code              string            `json:"code,omitempty"`
 	Name              string            `json:"name,omitempty"`
 	Names             Strings           `json:"names,omitempty"`
-	Price             decimal.Decimal   `json:"price,omitempty"`
-	BuyingPrice       decimal.Decimal   `json:"buying_price,omitempty"`
+	Price             Decimal           `json:"price,omitempty"`
+	BuyingPrice       Decimal           `json:"buying_price,omitempty"`
 	Description       Strings           `json:"description,omitempty"`
 	Description2      Strings           `json:"description2,omitempty"`
 	Tag               string            `json:"tag,omitempty"`

--- a/quotes.go
+++ b/quotes.go
@@ -2,19 +2,17 @@ package scoro
 
 import (
 	"errors"
-
-	"github.com/shopspring/decimal"
 )
 
 // QuoteLine struct represents quote lines data type of Scoro API.
 // https://api.scoro.com/api/#quoteLinesApiDocs
 type QuoteLine struct {
-	ProductID int             `json:"product_id"`
-	UnitPrice decimal.Decimal `json:"price"`
-	Amount    decimal.Decimal `json:"amount"`
-	Sum       decimal.Decimal `json:"sum"`
-	Vat       decimal.Decimal `json:"vat"`
-	Comment   Strings         `json:"comment"`
+	ProductID int     `json:"product_id"`
+	UnitPrice Decimal `json:"price"`
+	Amount    Decimal `json:"amount"`
+	Sum       Decimal `json:"sum"`
+	Vat       Decimal `json:"vat"`
+	Comment   Strings `json:"comment"`
 }
 
 // Quote struct represents quotes data type of Scoro API.
@@ -25,9 +23,9 @@ type Quote struct {
 	Discount                 float32           `json:"discount,omitempty"`
 	Discount2                float32           `json:"discount2,omitempty"`
 	Discount3                float32           `json:"discount3,omitempty"`
-	Sum                      decimal.Decimal   `json:"sum,omitempty"`
-	VatSum                   decimal.Decimal   `json:"vat_sum,omitempty"`
-	Vat                      decimal.Decimal   `json:"vat,omitempty"`
+	Sum                      Decimal           `json:"sum,omitempty"`
+	VatSum                   Decimal           `json:"vat_sum,omitempty"`
+	Vat                      Decimal           `json:"vat,omitempty"`
 	CompanyID                int               `json:"company_id,omitempty"`
 	PersonID                 int               `json:"person_id,omitempty"`
 	CompanyAddressID         int               `json:"company_address_id,omitempty"`

--- a/types.go
+++ b/types.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"strings"
 	"time"
+
+	"github.com/shopspring/decimal"
 )
 
 // TimePattern represents time format used in Scoro API requests and responses
@@ -162,4 +164,50 @@ func (t *Strings) UnmarshalJSON(data []byte) error {
 	}
 
 	return json.Unmarshal(data, t.Values)
+}
+
+// DecimalLike is interface for numeric values that can be represented as decimal
+type DecimalLike interface {
+	IntPart() int64
+	Exponent() int32
+}
+
+// Decimal is custom representation of decimal values to avoid using types from
+// 3rd part libraries in exported methods.
+type Decimal struct {
+	val decimal.Decimal
+}
+
+func NewDecimal(intPart int64, exponent int32) Decimal {
+	return Decimal{
+		val: decimal.New(intPart, exponent),
+	}
+}
+
+func CopyDecimal(val DecimalLike) Decimal {
+	return Decimal{
+		val: decimal.New(val.IntPart(), val.Exponent()),
+	}
+}
+
+func NewDecimalFromFloat(val float64) Decimal {
+	return Decimal{
+		val: decimal.NewFromFloat(val),
+	}
+}
+
+func (t Decimal) IntPart() int64 {
+	return t.IntPart()
+}
+
+func (t Decimal) Exponent() int32 {
+	return t.Exponent()
+}
+
+func (t Decimal) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.val)
+}
+
+func (t *Decimal) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &t.val)
 }


### PR DESCRIPTION
I as library developer
When I export method
Then I shouldn't use any 3rd party types
So that library user doesn't have any conflicts

**Tech:**

Make a wrapper around the `decimal.Decimal` type to provide a safe way to pass decimal values and hide 3rd party decimal type from library clients.