### PR TITLE
Fix type for date/deadline fields.

### DIFF
--- a/invoices.go
+++ b/invoices.go
@@ -40,8 +40,8 @@ type Invoice struct {
 	ProjectID                int               `json:"project_id,omitempty"`
 	Currency                 string            `json:"currency,omitempty"`
 	OwnerID                  int               `json:"owner_id,omitempty"`
-	Date                     Time              `json:"date,omitempty"`
-	Deadline                 Time              `json:"deadline,omitempty"`
+	Date                     Date              `json:"date,omitempty"`
+	Deadline                 Date              `json:"deadline,omitempty"`
 	Status                   string            `json:"status,omitempty"`
 	Description              string            `json:"description,omitempty"`
 	IsSent                   Bool              `json:"is_sent"`

--- a/orders.go
+++ b/orders.go
@@ -35,8 +35,8 @@ type Order struct {
 	ProjectID                int               `json:"project_id,omitempty"`
 	Currency                 string            `json:"currency,omitempty"`
 	OwnerID                  int               `json:"owner_id,omitempty"`
-	Date                     Time              `json:"date,omitempty"`
-	Deadline                 Time              `json:"deadline,omitempty"`
+	Date                     Date              `json:"date,omitempty"`
+	Deadline                 Date              `json:"deadline,omitempty"`
 	Status                   string            `json:"status,omitempty"`
 	Description              string            `json:"description,omitempty"`
 	IsSent                   Bool              `json:"is_sent"`

--- a/prepayments.go
+++ b/prepayments.go
@@ -40,8 +40,8 @@ type Prepayment struct {
 	ProjectID                int               `json:"project_id,omitempty"`
 	Currency                 string            `json:"currency,omitempty"`
 	OwnerID                  int               `json:"owner_id,omitempty"`
-	Date                     Time              `json:"date,omitempty"`
-	Deadline                 Time              `json:"deadline,omitempty"`
+	Date                     Date              `json:"date,omitempty"`
+	Deadline                 Date              `json:"deadline,omitempty"`
 	Status                   string            `json:"status,omitempty"`
 	Description              string            `json:"description,omitempty"`
 	IsSent                   Bool              `json:"is_sent"`

--- a/quotes.go
+++ b/quotes.go
@@ -34,8 +34,8 @@ type Quote struct {
 	ProjectID                int               `json:"project_id,omitempty"`
 	Currency                 string            `json:"currency,omitempty"`
 	OwnerID                  int               `json:"owner_id,omitempty"`
-	Date                     Time              `json:"date,omitempty"`
-	Deadline                 Time              `json:"deadline,omitempty"`
+	Date                     Date              `json:"date,omitempty"`
+	Deadline                 Date              `json:"deadline,omitempty"`
 	Status                   string            `json:"status,omitempty"`
 	Description              string            `json:"description,omitempty"`
 	IsSent                   Bool              `json:"is_sent"`


### PR DESCRIPTION
I as User
When I send request to quotes/invoices/prepayments/orders endpoints
Then I want to be able to get correctly parsed `date` and `deadline` fields
And I should not get error stating that date format is invalid