### PR TITLE
Fix json mapping for amount2 field

### DIFF
--- a/invoices.go
+++ b/invoices.go
@@ -13,7 +13,7 @@ type InvoiceLine struct {
 	Comment2        Strings           `json:"comment2"`
 	UnitPrice       Decimal           `json:"price"`
 	Amount          Decimal           `json:"amount"`
-	Amount2         Decimal           `json:"amount"`
+	Amount2         Decimal           `json:"amount2"`
 	Discount        Decimal           `json:"discount"`
 	Sum             Decimal           `json:"sum"`
 	Vat             Decimal           `json:"vat"`

--- a/orders.go
+++ b/orders.go
@@ -13,7 +13,7 @@ type OrderLine struct {
 	Comment2        Strings           `json:"comment2"`
 	UnitPrice       Decimal           `json:"price"`
 	Amount          Decimal           `json:"amount"`
-	Amount2         Decimal           `json:"amount"`
+	Amount2         Decimal           `json:"amount2"`
 	Discount        Decimal           `json:"discount"`
 	Sum             Decimal           `json:"sum"`
 	Vat             Decimal           `json:"vat"`

--- a/quotes.go
+++ b/quotes.go
@@ -13,7 +13,7 @@ type QuoteLine struct {
 	Comment2        Strings           `json:"comment2"`
 	UnitPrice       Decimal           `json:"price"`
 	Amount          Decimal           `json:"amount"`
-	Amount2         Decimal           `json:"amount"`
+	Amount2         Decimal           `json:"amount2"`
 	Discount        Decimal           `json:"discount"`
 	Sum             Decimal           `json:"sum"`
 	Vat             Decimal           `json:"vat"`


### PR DESCRIPTION
The `Amount2` go field should be mapped to the `amount2` JSON field to avoid conflict with `amount` field.