### PR TITLE
Replace comment type by string

### DIFF
--- a/examples/quotes/quotes.go
+++ b/examples/quotes/quotes.go
@@ -61,7 +61,7 @@ func createQuote(credentials scoro.Credentials, product scoro.Product) scoro.Quo
 		Lines: []scoro.QuoteLine{
 			scoro.QuoteLine{
 				Amount:    scoro.NewDecimalFromFloat(100.12),
-				Comment:   scoro.MakeStrings("Test comment", scoro.DefaultLang),
+				Comment:   "Test comment",
 				ProductID: *product.Id,
 				Sum:       scoro.NewDecimalFromFloat(1001.2),
 				UnitPrice: scoro.NewDecimalFromFloat(10),

--- a/invoices.go
+++ b/invoices.go
@@ -9,8 +9,8 @@ import (
 type InvoiceLine struct {
 	Id              int               `json:"id"`
 	ProductID       int               `json:"product_id"`
-	Comment         Strings           `json:"comment"`
-	Comment2        Strings           `json:"comment2"`
+	Comment         string            `json:"comment"`
+	Comment2        string            `json:"comment2"`
 	UnitPrice       Decimal           `json:"price"`
 	Amount          Decimal           `json:"amount"`
 	Amount2         Decimal           `json:"amount2"`

--- a/orders.go
+++ b/orders.go
@@ -9,8 +9,8 @@ import (
 type OrderLine struct {
 	Id              int               `json:"id"`
 	ProductID       int               `json:"product_id"`
-	Comment         Strings           `json:"comment"`
-	Comment2        Strings           `json:"comment2"`
+	Comment         string            `json:"comment"`
+	Comment2        string            `json:"comment2"`
 	UnitPrice       Decimal           `json:"price"`
 	Amount          Decimal           `json:"amount"`
 	Amount2         Decimal           `json:"amount2"`

--- a/quotes.go
+++ b/quotes.go
@@ -9,8 +9,8 @@ import (
 type QuoteLine struct {
 	Id              int               `json:"id"`
 	ProductID       int               `json:"product_id"`
-	Comment         Strings           `json:"comment"`
-	Comment2        Strings           `json:"comment2"`
+	Comment         string            `json:"comment"`
+	Comment2        string            `json:"comment2"`
 	UnitPrice       Decimal           `json:"price"`
 	Amount          Decimal           `json:"amount"`
 	Amount2         Decimal           `json:"amount2"`


### PR DESCRIPTION
We should send `comment` as simple string because Scoro doesn't support localization for this field.