### PR TITLE
Fix casual mistake in annotations for Relation entity

### DIFF
--- a/relations.go
+++ b/relations.go
@@ -12,7 +12,7 @@ type Relation struct {
 	// RelatedObjects is map containing related objects ID-s for each type on
 	// list request and list of ID-s on modify/delete request.
 	RelatedObjects interface{} `json:"related_objects,omitempty"`
-	Type           string      `json:"type	String,omitempty"`
+	Type           string      `json:"type,omitempty"`
 }
 type RelationList []Relation
 


### PR DESCRIPTION
I as User
When I make request to relations API
Want to be able to send `type` parameter
Currently, it is not serialized due to mistake in annotations
