### PR TITLE
Remove dependency on CompanyID from API url generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,16 @@ go-scoro is an Go client library for [Scoro API](https://api.scoro.com/api/)
 
 #### Documentation
 
-API documentation and examples are available via [godoc](https://godoc.org/github.com/lxmx/go-scoro). 
+API documentation and examples are available via [godoc](https://godoc.org/github.com/lxmx/go-scoro).
 
 If you need to check documentation locally before commit, run `godoc -http ":6060"` and open [http://localhost:6060/pkg/github.com/lxmx/go-scoro/](http://localhost:6060/pkg/github.com/lxmx/go-scoro/) in browser.
 
 #### Examples
 
-The [examples](./examples) directory contains more elaborate example applications. 
+The [examples](./examples) directory contains more elaborate example applications.
 
-`go run examples/<path>/<file>.go -company <company_id> -api_key <api_key>`
+`go run examples/<path>/<file>.go -company <company_id> -api_key <api_key> -subdomain <subdomain>`
 
-#### Note: 
+#### Note:
 
 The library does not have implementations of all Scoro resources. PRs for new resources and endpoints are welcome.

--- a/credentials.go
+++ b/credentials.go
@@ -6,6 +6,9 @@ type Credentials struct {
 	// ApiKey holds apiKey value that is listed in Settings > External Connections > API.
 	ApiKey string `json:"apiKey"`
 
-	// CompanyID holds company_account_idvalue that is listed in Settings > External Connections > API.
+	// CompanyID holds company_account_id value that is listed in Settings > External Connections > API.
 	CompanyID string `json:"company_account_id"`
+
+	// API subdomain
+	Subdomain string `json:"-"`
 }

--- a/examples/contacts/contacts.go
+++ b/examples/contacts/contacts.go
@@ -11,15 +11,16 @@ import (
 
 func main() {
 	company := flag.String("company", "", "Company id")
+	subdomain := flag.String("subdomain", "", "Subdomain id")
 	apiKey := flag.String("api_key", "", "Scoro API key")
 	flag.Parse()
 
-	if *company == "" || *apiKey == "" {
-		fmt.Println("Please specify company and api_key")
+	if *company == "" || *apiKey == "" || *subdomain == "" {
+		fmt.Println("Please specify company, api_key and subdomain")
 		return
 	}
 
-	credentials := scoro.Credentials{ApiKey: *apiKey, CompanyID: *company}
+	credentials := scoro.Credentials{ApiKey: *apiKey, CompanyID: *company, Subdomain: *subdomain}
 
 	fmt.Println("List contacts: ")
 	listContacts(credentials)

--- a/examples/products/products.go
+++ b/examples/products/products.go
@@ -11,15 +11,16 @@ import (
 
 func main() {
 	company := flag.String("company", "", "Company id")
+	subdomain := flag.String("subdomain", "", "Subdomain id")
 	apiKey := flag.String("api_key", "", "Scoro API key")
 	flag.Parse()
 
-	if *company == "" || *apiKey == "" {
-		fmt.Println("Please specify company and api_key")
+	if *company == "" || *apiKey == "" || *subdomain == "" {
+		fmt.Println("Please specify company, api_key and subdomain")
 		return
 	}
 
-	credentials := scoro.Credentials{ApiKey: *apiKey, CompanyID: *company}
+	credentials := scoro.Credentials{ApiKey: *apiKey, CompanyID: *company, Subdomain: *subdomain}
 
 	fmt.Println("List products: ")
 	listProducts(credentials)

--- a/examples/quotes/quotes.go
+++ b/examples/quotes/quotes.go
@@ -11,15 +11,16 @@ import (
 
 func main() {
 	company := flag.String("company", "", "Company id")
+	subdomain := flag.String("subdomain", "", "Subdomain id")
 	apiKey := flag.String("api_key", "", "Scoro API key")
 	flag.Parse()
 
-	if *company == "" || *apiKey == "" {
-		fmt.Println("Please specify company and api_key")
+	if *company == "" || *apiKey == "" || *subdomain == "" {
+		fmt.Println("Please specify company, api_key and subdomain")
 		return
 	}
 
-	credentials := scoro.Credentials{ApiKey: *apiKey, CompanyID: *company}
+	credentials := scoro.Credentials{ApiKey: *apiKey, CompanyID: *company, Subdomain: *subdomain}
 
 	fmt.Println("Create product: ")
 	product := createProduct(credentials)

--- a/request.go
+++ b/request.go
@@ -80,7 +80,7 @@ func (t Request) SetResponse(response ResponseType) Request {
 
 // View method sends "view" action request
 func (t Request) View(id string) (interface{}, error) {
-	url := makeUrl(t.credentials.CompanyID, t.entityType, "view", id)
+	url := makeUrl(t.credentials.Subdomain, t.entityType, "view", id)
 	body := requestBody{Credentials: t.credentials, Lang: t.lang}
 
 	return sendRequest(url, body, t.respType)
@@ -88,7 +88,7 @@ func (t Request) View(id string) (interface{}, error) {
 
 // List method sends "list" action request
 func (t Request) List(filter interface{}, page int, count int) (interface{}, error) {
-	url := makeUrl(t.credentials.CompanyID, t.entityType, "list")
+	url := makeUrl(t.credentials.Subdomain, t.entityType, "list")
 	body := requestBody{
 		Credentials: t.credentials,
 		Lang:        t.lang,
@@ -102,7 +102,7 @@ func (t Request) List(filter interface{}, page int, count int) (interface{}, err
 
 // Modify method sends "modify" action request
 func (t Request) Modify(obj interface{}) (interface{}, error) {
-	url := makeUrl(t.credentials.CompanyID, t.entityType, "modify")
+	url := makeUrl(t.credentials.Subdomain, t.entityType, "modify")
 	body := requestBody{Credentials: t.credentials, Lang: t.lang, Request: obj}
 
 	return sendRequest(url, body, t.respType)
@@ -110,7 +110,7 @@ func (t Request) Modify(obj interface{}) (interface{}, error) {
 
 // Delete method sends "delete" action request
 func (t Request) Delete(id int, filter interface{}) (interface{}, error) {
-	url := makeUrl(t.credentials.CompanyID, t.entityType, "delete", strconv.Itoa(id))
+	url := makeUrl(t.credentials.Subdomain, t.entityType, "delete", strconv.Itoa(id))
 	body := requestBody{Credentials: t.credentials, Lang: t.lang, Request: filter}
 
 	return sendRequest(url, body, t.respType)
@@ -127,8 +127,8 @@ type requestBody struct {
 	Filter      interface{} `json:"filter,omitempty"`
 }
 
-func makeUrl(companyId string, entityType string, action string, params ...string) string {
-	baseURL := fmt.Sprintf("https://%v.scoro.com/api/v1", companyId)
+func makeUrl(subdomain string, entityType string, action string, params ...string) string {
+	baseURL := fmt.Sprintf("https://%v.scoro.com/api/v1", subdomain)
 
 	urlParts := []string{baseURL, entityType, action}
 	urlParts = append(urlParts, params...)


### PR DESCRIPTION
I as Library user
When I call API methods
I want to specify subdomain
So that I can use subdomains that differ from CompanyID